### PR TITLE
No need to edit anything in the repository to publish to Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,13 @@ $ ant -f ./make/langtools/netbeans/nb-javac zip-nb-javac-sources
 2. Configure the maven installation so that the credentials are made available
    for the server with the id oss.sonatype.org
 
-3. If you want to publish nb-javac as a non-oracle contributor under your own
-   groupId, you need to update the `make/langtools/netbeans/nb-javac/pom-nb-javac`
-   file. You need to update at least the elements: `groupId`, `developers`,
-   `scm`, `url` and `description`.
-
-4. Run
+3. Run
    ```
    ant -f ./make/langtools/netbeans/nb-javac publish-to-ossrh-snapshots -Dmaven.groupId=your.grp.id
    ```
    to publish snapshot artifacts (https://oss.sonatype.org/content/repositories/snapshots/)
 
-5. Run
+4. Run
    ```
    ant -f ./make/langtools/netbeans/nb-javac publish-to-maven-central -Dmaven.groupId=your.grp.id
    ```


### PR DESCRIPTION
Thanks a lot for accepting #2 prepared by @matthiasblaesing which also includes my "pluggable groupId" idea. Now it is time for 3rd parties (like @eppleton) to try to upload the snapshot bits using:
```bash
$ ant -f ./make/langtools/netbeans/nb-javac publish-to-ossrh-snapshots -Dmaven.groupId=their.grp.id
```
I did some testing previously and it seemed to work, but I don't have OSSRH account so, my test always ended with 403 - access denied. Now when the change is in, real testing is needed...

Also, when re-reading the how-to I realized it still contains original step 3 that my "pluggable group ID" eliminated. This PR fixes that by removing the step. It shall be enough to execute
```bash
$ ant -f ./make/langtools/netbeans/nb-javac publish-to-ossrh-snapshots -Dmaven.groupId=their.grp.id
```
to handle the upload.