### PR TITLE
Fix for Apache NetBeans issue 4950 - repeated NPEs during scanning

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -1469,9 +1469,9 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
      */
     public void close() {
         filer.close();
-        if (discoveredProcs != null) // Make calling close idempotent
-            discoveredProcs.close();
-        discoveredProcs = null;
+//        if (discoveredProcs != null) // Make calling close idempotent
+//            discoveredProcs.close();
+//        discoveredProcs = null;
     }
 
     private List<ClassSymbol> getTopLevelClasses(List<? extends JCCompilationUnit> units) {


### PR DESCRIPTION
Repeated NPEs are thrown during classpath scanning, making the IDE unusable during classpath scanning

See https://issues.apache.org/jira/browse/NETBEANS-4950 for details.

TL/DR: NetBeans reuses the JavacProcessingEnvironment; nulling the set of discovered processors on
close severely breaks things.