### PR TITLE
Preparing JDK8-ready update of nb-javac 15.0.0.x

### DIFF
--- a/make/langtools/netbeans/nb-javac/build.xml
+++ b/make/langtools/netbeans/nb-javac/build.xml
@@ -67,6 +67,12 @@
 
     -->
 
+    <fail message="Please use JDK8 to build nb-javac!">
+        <condition>
+            <available classname="java.lang.Module"/>
+        </condition>
+    </fail>
+
     <!-- suppress javadoc generation for this library, as its wrappers do it -->
     <target name="-javadoc-build"/>
     

--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -104,4 +104,4 @@ javac.test.classpath=\
     ${build.dir}/lib/hamcrest-core-1.3.jar
 debug.classpath=${run.classpath}
 jnlp.enabled=false
-nb-javac-ver=15.0.0.1
+nb-javac-ver=15.0.0.2


### PR DESCRIPTION
Thanks to @monacotoni a release of `nb-javac 15.0.0.1` has been uploaded to [Maven central](https://search.maven.org/artifact/com.dukescript.nbjavac/nb-javac/15.0.0.1/jar). Alas, thanks to incomplete instructions provided by me, the version `15.0.0.1` cannot run on JDK8 (which is its main goal). Please beg my pardon. This PR tries to fix it:

- It includes a check to verify the `ant` build is running on JDK8. 
- It increases the `nb-javac` version of 15.0.0.2 - as we can't replace what has been uploaded to Maven central.
- There are no changes in the code - this is versioning change only to satisfy Maven upload rules

@Akshay-Gupta-Oracle please consider merging this and tag the release "somehow". I write "somehow" as there is the `release130` branch and the actual release naming scheme is up to you. However I'd very much prefer to use `git tag 15.0.0.2`. Once the PR is in and there is a tag/branch let's ask @monacotoni to upload 15.0.0.2 to Maven.

Please note that accepting this PR and tagging doesn't yet constitute a release. As such I'd suggest to do it without further delay to compensate for my failure in preparing 15.0.0.1 Maven release properly. Once again please accept my apology and sorry for the unnecessary inconveniences.

CCing @eppleton, @jlahoda, @matthiasblaesing 