### PR TITLE
Avoid closing the JavacProcessingEnvironment, so that subsequent processing in the same instance of javac will work.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -1443,9 +1443,6 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
 	        } else {
 	            compiler.todo.clear();
 	        }
-
-	        // Free resources
-	        this.close();
         } catch (Throwable t) {
             rethrowAbort(t);
             LOGGER.log(Level.INFO, "Error while re-entering:", t);


### PR DESCRIPTION
An alternative to:
https://github.com/oracle/nb-javac/pull/7

I believe not calling the `close()` method is what nb-javac was doing before:
https://hg.netbeans.org/main/nb-java-x/diff/a9d99edf3239/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
