### PR TITLE
Adding missing license header into DocCommentParserTest

### DIFF
--- a/make/langtools/netbeans/nb-javac/test/com/sun/tools/javac/parser/DocCommentParserTest.java
+++ b/make/langtools/netbeans/nb-javac/test/com/sun/tools/javac/parser/DocCommentParserTest.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright 2003-2004 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Sun designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Sun in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ */
 package com.sun.tools.javac.parser;
 
 import com.sun.source.doctree.DocCommentTree;


### PR DESCRIPTION
While testing compliance of `nb-javac` sources with respect to _Classpath "exception"_ I [performed grep](https://lists.apache.org/thread.html/r821d9e9fdc8d9fd5663e7c326d25e4626e1a27eb13e45f4d639ea199%40%3Cdev.netbeans.apache.org%3E) over the sources and realized one `.java` file was missing its license header completely:
```bash
find . -type f | grep java | while read X; do grep -r 'particular file as subject to the 
"Classpath" exception as provided' $X >/dev/null || echo No CPE in $X; done
No CPE in ./make/langtools/netbeans/nb-javac/test/com/sun/tools/javac/parser/
DocCommentParserTest.java
```
Certainly that's not intentional, but it's better to keep things clean when it comes to licenses. Let's add the missing license header. Thank you!

PS: I copied the license header from the sibling `.java` file in the same directory.