### PR TITLE
Constructor/method signatures differ from the corresponding signatures in original javac.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2392,6 +2392,10 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             return true;
         }
 
+        public ErrorType(Name name, TypeSymbol container, Type originalType) {
+            this(new ClassSymbol(PUBLIC|STATIC|ACYCLIC, name, null, container), originalType);
+        }
+
         public ErrorType(Name name, Symbol container, Type originalType) {
             this(new ClassSymbol(PUBLIC|STATIC|ACYCLIC, name, null, container), originalType);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -3576,6 +3576,10 @@ public class Types {
         return new ErrorType(c, originalType);
     }
 
+    public Type createErrorType(Name name, TypeSymbol container, Type originalType) {
+        return new ErrorType(name, container, originalType);
+    }
+
     public Type createErrorType(Name name, Symbol container, Type originalType) {
         return new ErrorType(name, container, originalType);
     }


### PR DESCRIPTION
Constructor/method signatures differ from the corresponding signatures in original javac which prevents the applications compiled against the original javac from using the nb-javac instead. See issue [NETBEANS-6080](https://github.com/apache/netbeans/pull/3199).