### PR TITLE
Fixed stripLeading() because it will *ALWAYS* throw and ClassCastExce…

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/TextBlockSupport.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/TextBlockSupport.java
@@ -160,9 +160,8 @@ class TextBlockSupport {
      * Invoke String::stripLeading through reflection.
      */
     static String stripLeading(String string) {
-        boolean isBlankStr;
         try {
-            string = (String) isBlank.invoke(null, string);
+            string = (String) stripLeading.invoke(null, string);
         } catch (InvocationTargetException | IllegalAccessException ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
…ption

It should be invoking String::stripLeading() instead of String::isBlank()